### PR TITLE
Add access control header to js staticfiles

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,7 @@ module.exports = {
   async headers() {
     return [
       {
-        source: "/js/*",
+        source: "/js/:filename*",
         headers: [
           {
             key: "Access-Control-Allow-Origin",

--- a/next.config.js
+++ b/next.config.js
@@ -6,5 +6,18 @@ module.exports = {
         destination: '/doc/index.html'
       }
     ]
+  },
+  async headers() {
+    return [
+      {
+        source: "/js/*",
+        headers: [
+          {
+            key: "Access-Control-Allow-Origin",
+            value: "https://wise-copywriter-025422.framer.app"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
Following [the outline from their docs](https://nextjs.org/docs/pages/api-reference/next-config-js/headers) to add `Access-Control-Allow-Origin` header to serving js staticfiles through next
